### PR TITLE
CDDIG-27867: Update TPP Guidelines in brandid.md (Branded Cards)

### DIFF
--- a/brandedcards/brandid.md
+++ b/brandedcards/brandid.md
@@ -3,68 +3,73 @@
 Brand ID parameter is required when calling the authorizationUrl from the swagger file.
 Accepted values for Branded Card Accouts and Corporate Card Accounts can be found in the tables below
 
-## Branded Cards Brand ID 
+## Branded Cards Brand ID
+
 **These works with the api Branded Card Accounts, not to be used with the api Corporate Card Accounts**
 
 #### Denmark
 
-Brand | Brand ID
------------- | -------------
-Circle K | ckdk
-Eurocard| ecdk
-GlobeCard | gcdk
-Jyske | jydk
-SAS | sadk
+| Brand     | Brand ID |
+| --------- | -------- |
+| Circle K  | ckdk     |
+| Eurocard  | ecdk     |
+| GlobeCard | gcdk     |
+| Jyske     | jydk     |
+| SAS       | sadk     |
 
 #### Finland
 
-Brand | Brand ID
------------- | -------------
-Eurocard| ecfi
-Finnair | fafi
-SAS | safi
+| Brand    | Brand ID |
+| -------- | -------- |
+| Eurocard | ecfi     |
+| Finnair  | fafi     |
+| SAS      | safi     |
 
 #### Norway
 
-Brand | Brand ID
------------- | -------------
-Cirkle K | stno
-Esso | esno
-Eurocard | ecno
-Finnair | fano
-GlobeCard | gcno
-Landkreditt | lkno
-Strawberry | cono
-SAS | sano
-SEB Selected | ssno
-Volvo kortet | vono
-
+| Brand        | Brand ID |
+| ------------ | -------- |
+| Cirkle K     | stno     |
+| Esso         | esno     |
+| Eurocard     | ecno     |
+| Finnair      | fano     |
+| GlobeCard    | gcno     |
+| Landkreditt  | lkno     |
+| Strawberry   | cono     |
+| SAS          | sano     |
+| SEB Selected | ssno     |
+| Volvo kortet | vono     |
 
 #### Sweden
 
-Brand | Brand ID
------------- | -------------
-Cirkle K | stse
-Eurocard  | ecse
-Finnair | fase
-INGO | jese
-NK | nkse
-Strawberry | cose
-Opel | opse
-SAAB | sbse
-SAS | sase
-Scandic | scse
-SJ | sjse
-Wallet | wase
-
+| Brand      | Brand ID |
+| ---------- | -------- |
+| Cirkle K   | stse     |
+| Eurocard   | ecse     |
+| Finnair    | fase     |
+| INGO       | jese     |
+| NK         | nkse     |
+| Strawberry | cose     |
+| Opel       | opse     |
+| SAAB       | sbse     |
+| SAS        | sase     |
+| Scandic    | scse     |
+| SJ         | sjse     |
+| Wallet     | wase     |
 
 ## Corporate Brand ID's
+
 **These works with the api Corporate Card Accounts, not for use with the api Branded Card Accounts**
 
-Brand | Brand ID
------------- | -------------
-Eurocard | ccms
-Jyske  | jydk
-DNB | dnno
-OP | opfi
-SEB | ssse
+> **Migration note:** The `ccms` brand ID (previously used for Eurocard) has been retired. Use the market-specific AirPlus brand IDs below instead.
+
+| Brand           | Brand ID |
+| --------------- | -------- |
+| AirPlus Sweden  | apse     |
+| AirPlus Finland | apfi     |
+| AirPlus Denmark | apdk     |
+| AirPlus Norway  | apno     |
+| Jyske           | jydk     |
+| DNB             | dnno     |
+| OP              | opfi     |
+| SEB             | ssse     |


### PR DESCRIPTION
**Description:**

Updates Corporate Card Accounts brand IDs to reflect the Eurocard → AirPlus rebrand.

**Changes:**

- Retired the ccms brand ID (Eurocard)
- Added market-specific AirPlus brand IDs: apse (Sweden), apfi (Finland), apdk (Denmark), apno (Norway)
- Added migration note for TTPs currently using ccms

Impact: TTPs integrating with the Corporate Card Accounts API must migrate from ccms to the appropriate market-specific AirPlus brand ID.